### PR TITLE
Resolve duplicate sigmoid helper definition

### DIFF
--- a/1_de_8
+++ b/1_de_8
@@ -155,17 +155,11 @@ def _hash_obj(obj: Any) -> str:
         return hashlib.sha256(str(obj).encode()).hexdigest()
 
 def _sigmoid(x: float, beta: float, mid: float) -> float:
-def _sigmoid(x: float, beta: float, mid: float) -> float:
-    if beta == 0.0:
-        return 0.5  # Neutral value when beta is zero
-def _sigmoid(x: float, beta: float, mid: float) -> float:
     if beta == 0.0:
         return 0.5  # Neutral value when beta is zero
     try:
         return 1.0 / (1.0 + math.exp(-beta * (x - mid)))
     except OverflowError:
-        return 0.0 if (-beta * (x - mid)) > 0 else 1.0
-        return 0.0 if (-beta * (x - mid)) > 0 else 1.0
         return 0.0 if (-beta * (x - mid)) > 0 else 1.0
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- collapse the multiple `_sigmoid` definitions introduced during the merge into a single helper that preserves neutral and overflow handling
- ensure the master core module imports cleanly again so the branch can merge without syntax conflicts

## Testing
- for f in *_de_8; do python3 -m py_compile $f; done

------
https://chatgpt.com/codex/tasks/task_e_68dae74f86fc83338c0669479597328a