### PR TITLE
Fix config defaults and guard Gemini provider initialization

### DIFF
--- a/penin/config.py
+++ b/penin/config.py
@@ -1,20 +1,18 @@
 from typing import Optional
-
-from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    OPENAI_API_KEY: Optional[str] = Field(None, min_length=1)
-    DEEPSEEK_API_KEY: Optional[str] = Field(None, min_length=1)
-    MISTRAL_API_KEY: Optional[str] = Field(None, min_length=1)
-    GEMINI_API_KEY: Optional[str] = Field(None, min_length=1)
-    ANTHROPIC_API_KEY: Optional[str] = Field(None, min_length=1)
-    XAI_API_KEY: Optional[str] = Field(None, min_length=1)
-    HUGGINGFACE_TOKEN: Optional[str] = Field(None, min_length=1)
-    GITHUB_TOKEN: Optional[str] = Field(None, min_length=1)
-    KAGGLE_USERNAME: Optional[str] = Field(None, min_length=1)
-    KAGGLE_KEY: Optional[str] = Field(None, min_length=1)
+    OPENAI_API_KEY: Optional[str] = None
+    DEEPSEEK_API_KEY: Optional[str] = None
+    MISTRAL_API_KEY: Optional[str] = None
+    GEMINI_API_KEY: Optional[str] = None
+    ANTHROPIC_API_KEY: Optional[str] = None
+    XAI_API_KEY: Optional[str] = None
+    HUGGINGFACE_TOKEN: Optional[str] = None
+    GITHUB_TOKEN: Optional[str] = None
+    KAGGLE_USERNAME: Optional[str] = None
+    KAGGLE_KEY: Optional[str] = None
 
     PENIN_MAX_PARALLEL_PROVIDERS: int = 3
     PENIN_MAX_TOKENS_PER_ROUND: int = 30000

--- a/penin/ingest/kaggle_ingestor.py
+++ b/penin/ingest/kaggle_ingestor.py
@@ -3,7 +3,7 @@ import re
 from typing import Any, Dict
 
 
-SAFE_QUERY_PATTERN = re.compile(r"^[\w\s-]+$")
+SAFE_QUERY_PATTERN = re.compile(r"^[a-zA-Z0-9\s.,-]+$")
 
 
 async def kaggle_search_datasets(query: str, max_results: int = 10) -> Dict[str, Any]:

--- a/penin/providers/gemini_provider.py
+++ b/penin/providers/gemini_provider.py
@@ -13,7 +13,11 @@ class GeminiProvider(BaseProvider):
     def __init__(self, model: Optional[str] = None):
         self.name = "gemini"
         self.model = model or settings.GEMINI_MODEL
-        genai.configure(api_key=settings.GEMINI_API_KEY)
+        api_key = settings.GEMINI_API_KEY
+        if not api_key:
+            raise ValueError("GEMINI_API_KEY is not configured")
+
+        genai.configure(api_key=api_key)
         self.client = genai.GenerativeModel(self.model)
 
     async def chat(


### PR DESCRIPTION
## Summary
- remove the unused Field dependency in the Settings model and restore simple optional defaults
- relax the Kaggle dataset query pattern without allowing underscores to match reviewer guidance
- raise a clear error when the Gemini provider is initialized without an API key configured

## Testing
- python -m compileall penin

------
https://chatgpt.com/codex/tasks/task_e_68daed66a2dc8333bdfdea96b1cf6606