### PR TITLE
feat(router): aggregate provider costs with pricing helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Provider keys (preencha com seus valores ou use variáveis de ambiente no servidor)
+# Providers
 OPENAI_API_KEY=
 DEEPSEEK_API_KEY=
 MISTRAL_API_KEY=
@@ -9,7 +9,7 @@ HUGGINGFACE_TOKEN=
 KAGGLE_USERNAME=
 KAGGLE_KEY=
 
-# PENIN runtime
+# Runtime PENIN
 PENIN_BUDGET_DAILY_USD=5.0
 PENIN_METRICS_TOKEN=change-me
 PENIN_CACHE_HMAC_KEY=change-me

--- a/penin/providers/anthropic_provider.py
+++ b/penin/providers/anthropic_provider.py
@@ -4,6 +4,7 @@ import time
 import anthropic
 
 from penin.config import settings
+from penin.providers.pricing import estimate_cost, usage_value
 
 from .base import BaseProvider, LLMResponse, Message, Tool
 
@@ -26,7 +27,24 @@ class AnthropicProvider(BaseProvider):
         if system:
             msgs.append({"role": "system", "content": system})
         msgs += messages
-        resp = await asyncio.to_thread(self.client.messages.create, model=self.model, max_tokens=2048, messages=msgs)
+        resp = await asyncio.to_thread(
+            self.client.messages.create,
+            model=self.model,
+            max_tokens=2048,
+            messages=msgs,
+        )
         content = resp.content[0].text if getattr(resp, "content", None) else ""
+        usage = getattr(resp, "usage", None)
+        tokens_in = usage_value(usage, "input_tokens")
+        tokens_out = usage_value(usage, "output_tokens")
+        cost_usd = estimate_cost(self.name, self.model, tokens_in, tokens_out)
         end = time.time()
-        return LLMResponse(content=content, model=self.model, provider=self.name, latency_s=end - start)
+        return LLMResponse(
+            content=content,
+            model=self.model,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            provider=self.name,
+            cost_usd=cost_usd,
+            latency_s=end - start,
+        )

--- a/penin/providers/mistral_provider.py
+++ b/penin/providers/mistral_provider.py
@@ -4,6 +4,7 @@ import time
 from mistralai import Mistral
 
 from penin.config import settings
+from penin.providers.pricing import estimate_cost, usage_value
 
 from .base import BaseProvider, LLMResponse, Message, Tool
 
@@ -28,5 +29,17 @@ class MistralProvider(BaseProvider):
         msgs += messages
         resp = await asyncio.to_thread(self.client.chat.complete, model=self.model, messages=msgs)
         content = resp.choices[0].message.content
+        usage = getattr(resp, "usage", None)
+        tokens_in = usage_value(usage, "prompt_tokens")
+        tokens_out = usage_value(usage, "completion_tokens")
+        cost_usd = estimate_cost(self.name, self.model, tokens_in, tokens_out)
         end = time.time()
-        return LLMResponse(content=content, model=self.model, provider=self.name, latency_s=end - start)
+        return LLMResponse(
+            content=content,
+            model=self.model,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            provider=self.name,
+            cost_usd=cost_usd,
+            latency_s=end - start,
+        )

--- a/penin/providers/pricing.py
+++ b/penin/providers/pricing.py
@@ -1,0 +1,102 @@
+"""Pricing helpers for provider cost estimation.
+
+This module centralises model pricing references so that individual
+providers can translate token usage metadata into USD cost estimates.
+The prices here are intentionally conservative and should be reviewed
+periodically against vendor documentation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "Pricing",
+    "MODEL_PRICING",
+    "get_pricing",
+    "estimate_cost",
+    "usage_value",
+]
+
+
+@dataclass(frozen=True)
+class Pricing:
+    """Represents pricing information per 1K tokens."""
+
+    prompt: float
+    completion: float
+
+
+MODEL_PRICING: dict[str, dict[str, Pricing]] = {
+    "openai": {
+        "gpt-4o": Pricing(prompt=0.005, completion=0.015),
+        "gpt-4o-mini": Pricing(prompt=0.0006, completion=0.0024),
+        "default": Pricing(prompt=0.005, completion=0.015),
+    },
+    "anthropic": {
+        "claude-3-5-sonnet-20241022": Pricing(prompt=0.003, completion=0.015),
+        "claude-3-5-sonnet": Pricing(prompt=0.003, completion=0.015),
+        "default": Pricing(prompt=0.003, completion=0.015),
+    },
+    "deepseek": {
+        "deepseek-chat": Pricing(prompt=0.00014, completion=0.00028),
+        "default": Pricing(prompt=0.00014, completion=0.00028),
+    },
+    "mistral": {
+        "mistral-large-latest": Pricing(prompt=0.008, completion=0.024),
+        "default": Pricing(prompt=0.008, completion=0.024),
+    },
+    "gemini": {
+        "gemini-1.5-pro": Pricing(prompt=0.0035, completion=0.0105),
+        "default": Pricing(prompt=0.0035, completion=0.0105),
+    },
+    "grok": {
+        "grok-beta": Pricing(prompt=0.01, completion=0.03),
+        "default": Pricing(prompt=0.01, completion=0.03),
+    },
+}
+
+
+def _normalise_key(value: str | None) -> str:
+    return (value or "").lower()
+
+
+def get_pricing(provider: str, model: str) -> Pricing:
+    """Fetch pricing for the given provider/model pair."""
+
+    provider_key = _normalise_key(provider)
+    model_key = _normalise_key(model)
+    provider_prices = MODEL_PRICING.get(provider_key, {})
+    if model_key in provider_prices:
+        return provider_prices[model_key]
+    if "default" in provider_prices:
+        return provider_prices["default"]
+    return Pricing(prompt=0.0, completion=0.0)
+
+
+def usage_value(usage: Any, key: str) -> int:
+    """Extract integer usage data from SDK-specific structures."""
+
+    if usage is None:
+        return 0
+    if isinstance(usage, dict):
+        value = usage.get(key, 0)
+    else:
+        value = getattr(usage, key, 0)
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def estimate_cost(provider: str, model: str, prompt_tokens: int, completion_tokens: int) -> float:
+    """Estimate USD cost from token counts using provider pricing."""
+
+    pricing = get_pricing(provider, model)
+    prompt_cost = (prompt_tokens / 1000.0) * pricing.prompt
+    completion_cost = (completion_tokens / 1000.0) * pricing.completion
+    total = prompt_cost + completion_cost
+    # Guard against negative or NaN inputs
+    return max(total, 0.0)
+

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,40 @@
+"""Tests for provider pricing utilities."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure project root is importable when package is not installed
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from penin.providers.pricing import estimate_cost, get_pricing, usage_value
+
+
+def test_get_pricing_known_model():
+    pricing = get_pricing("openai", "gpt-4o")
+    assert pricing.prompt > 0
+    assert pricing.completion > 0
+
+
+def test_estimate_cost_uses_tokens():
+    cost = estimate_cost("openai", "gpt-4o", prompt_tokens=1000, completion_tokens=500)
+    # 1000 prompt tokens * 0.005 + 500 completion * 0.015 = 0.0125
+    assert cost == pytest.approx(0.0125, rel=1e-6)
+
+
+def test_usage_value_handles_various_structures():
+    class UsageObj:
+        prompt_tokens = 123
+
+    assert usage_value({"prompt_tokens": 10}, "prompt_tokens") == 10
+    assert usage_value(UsageObj(), "prompt_tokens") == 123
+    assert usage_value(None, "prompt_tokens") == 0
+
+
+def test_unknown_model_has_zero_cost():
+    cost = estimate_cost("unknown", "model", 1000, 1000)
+    assert cost == 0.0
+

--- a/tests/test_router_syntax.py
+++ b/tests/test_router_syntax.py
@@ -1,11 +1,21 @@
 """Teste para verificar sintaxe e instanciamento do router"""
 
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the repository root is importable when running tests in isolation
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from penin.router import MultiLLMRouter
 
 
 class DummyProvider:
     """Provider dummy para testes"""
-    
+
     async def chat(self, *args, **kwargs):
         from penin.providers.base import LLMResponse
         return LLMResponse("ok", "dummy", cost_usd=0.0, latency_s=0.1)
@@ -15,7 +25,7 @@ def test_router_instantiation():
     """Test router instantiation"""
     providers = [DummyProvider()]
     router = MultiLLMRouter(providers, daily_budget_usd=0.1)
-    
+
     assert hasattr(router, "ask") and callable(router.ask)
     assert hasattr(router, "get_usage_stats") and callable(router.get_usage_stats)
     assert hasattr(router, "get_budget_status") and callable(router.get_budget_status)
@@ -25,7 +35,7 @@ def test_router_budget_tracking():
     """Test budget tracking functionality"""
     providers = [DummyProvider()]
     router = MultiLLMRouter(providers, daily_budget_usd=1.0)
-    
+
     # Check initial budget status
     status = router.get_budget_status()
     assert "daily_budget_usd" in status
@@ -34,7 +44,7 @@ def test_router_budget_tracking():
     assert "usage_percentage" in status
     assert "budget_exceeded" in status
     assert "date" in status
-    
+
     # Check usage stats
     stats = router.get_usage_stats()
     assert "daily_spend_usd" in stats
@@ -48,17 +58,17 @@ def test_router_budget_tracking():
 def test_router_cost_tracker():
     """Test CostTracker functionality"""
     from penin.router import CostTracker
-    
+
     tracker = CostTracker(budget_usd=5.0)
-    
+
     # Test initial state
     assert not tracker.is_over_budget()
     assert tracker.remaining_budget() == 5.0
-    
+
     # Test recording
     tracker.record("test_provider", 1.0, 100)
     assert tracker.remaining_budget() == 4.0
-    
+
     # Test over budget
     tracker.record("test_provider", 5.0, 500)
     assert tracker.is_over_budget()
@@ -69,19 +79,19 @@ def test_router_scoring():
     """Test router scoring functionality"""
     providers = [DummyProvider()]
     router = MultiLLMRouter(providers, daily_budget_usd=1.0)
-    
+
     from penin.providers.base import LLMResponse
-    
+
     # Test scoring with different responses
     response1 = LLMResponse("content", "provider1", cost_usd=0.1, latency_s=0.5)
     response2 = LLMResponse("content", "provider2", cost_usd=0.2, latency_s=0.3)
-    
+
     score1 = router._score(response1)
     score2 = router._score(response2)
-    
+
     assert isinstance(score1, float)
     assert isinstance(score2, float)
-    
+
     # Lower cost and latency should give higher score
     assert score1 > score2
 
@@ -90,11 +100,48 @@ def test_router_reset_budget():
     """Test budget reset functionality"""
     providers = [DummyProvider()]
     router = MultiLLMRouter(providers, daily_budget_usd=1.0)
-    
+
     # Reset budget
     router.reset_daily_budget(2.0)
-    
+
     status = router.get_budget_status()
     assert status["daily_budget_usd"] == 2.0
     assert status["current_usage_usd"] == 0.0
     assert status["remaining_usd"] == 2.0
+
+
+async def _fake_response(content: str, cost: float, tokens: int):
+    from penin.providers.base import LLMResponse
+
+    return LLMResponse(
+        content,
+        "dummy",
+        tokens_in=tokens,
+        tokens_out=tokens // 2,
+        cost_usd=cost,
+        latency_s=0.1,
+    )
+
+
+class _CostlyProvider:
+    def __init__(self, cost: float, tokens: int):
+        self.cost = cost
+        self.tokens = tokens
+
+    async def chat(self, *args, **kwargs):
+        return await _fake_response("ok", self.cost, self.tokens)
+
+
+@pytest.mark.asyncio
+async def test_router_records_all_provider_costs():
+    providers = [_CostlyProvider(0.2, 100), _CostlyProvider(0.4, 200)]
+    router = MultiLLMRouter(providers, daily_budget_usd=5.0)
+
+    response = await router.ask([{"role": "user", "content": "ping"}])
+
+    assert response.content == "ok"
+
+    stats = router.get_usage_stats()
+    assert stats["daily_spend_usd"] == pytest.approx(0.6, rel=1e-6)
+    assert stats["total_tokens"] == 100 + 50 + 200 + 100
+    assert stats["request_count"] == 1


### PR DESCRIPTION
## Summary
- add shared pricing helpers so providers can estimate cost_usd from SDK usage metadata
- update each provider to populate token counts and feed the router aggregated spend/tokens across concurrent calls
- extend router and pricing tests to cover aggregated cost tracking and helper behaviour

## Testing
- pytest tests/test_pricing.py tests/test_router_syntax.py
- pytest *(fails: multiple pre-existing suite failures unrelated to this change)*
- ruff check penin/providers/pricing.py penin/router.py tests/test_router_syntax.py tests/test_pricing.py


------
https://chatgpt.com/codex/tasks/task_e_68dbde9b8d988333b13ddfe1965b6cb3